### PR TITLE
Update port, metric types, add pool metrics, fix logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/rekzi/clamav-prometheus-exporter/
 COPY . .
 # CGO_ENABLED=0 to build a statically-linked executable
 
-ENV CGO_ENABLED=0 
+ENV CGO_ENABLED=0
 RUN go build -installsuffix 'static' -o clamav-prometheus-exporter .
 
 # Final stage: the running container.
@@ -20,5 +20,5 @@ RUN adduser -S -u 1000 prometheus \
 
 USER 1000
 # Default port for metrics exporters
-EXPOSE 9090
+EXPOSE 9810
 ENTRYPOINT [ "/bin/clamav-prometheus-exporter" ]

--- a/README.md
+++ b/README.md
@@ -22,30 +22,30 @@ Exports metrics from [ClamAV](https://www.clamav.net/) as Prometheus metrics.
 ```
 # HELP clamav_build_info Shows ClamAV Build Info
 # TYPE clamav_build_info gauge
-clamav_build_info{clamav_version="0.102.4",database_version="25913"} 1
-# HELP clamav_mem_heap Shows heap memory usage
-# TYPE clamav_mem_heap gauge
-clamav_mem_heap 3.656
-# HELP clamav_mem_mmap Shows mmap memory usage
-# TYPE clamav_mem_mmap gauge
-clamav_mem_mmap 0.129
-# HELP clamav_mem_used Shows used memory usage
-# TYPE clamav_mem_used gauge
-clamav_mem_used 3.236
-# HELP clamav_queue Shows queued items
-# TYPE clamav_queue counter
-clamav_queue 0
+clamav_build_info{clamav_version="0.102.4",database_version="26091"} 1
+# HELP clamav_mem_heap_bytes Shows heap memory usage in bytes
+# TYPE clamav_mem_heap_bytes gauge
+clamav_mem_heap_bytes 1.090783104e+06
+# HELP clamav_mem_mmap_bytes Shows mmap memory usage in bytes
+# TYPE clamav_mem_mmap_bytes gauge
+clamav_mem_mmap_bytes 1.076747264e+06
+# HELP clamav_mem_used_bytes Shows used memory usage in bytes
+# TYPE clamav_mem_used_bytes gauge
+clamav_mem_used_bytes 1.076783104e+06
+# HELP clamav_queue_length Shows queued items
+# TYPE clamav_queue_length gauge
+clamav_queue_length 0
 # HELP clamav_threads_idle Shows idle threads
-# TYPE clamav_threads_idle counter
+# TYPE clamav_threads_idle gauge
 clamav_threads_idle 0
 # HELP clamav_threads_live Shows live threads
-# TYPE clamav_threads_live counter
+# TYPE clamav_threads_live gauge
 clamav_threads_live 1
 # HELP clamav_threads_max Shows max threads
-# TYPE clamav_threads_max counter
-clamav_threads_max 12
+# TYPE clamav_threads_max gauge
+clamav_threads_max 10
 # HELP clamav_up Shows UP Status
-# TYPE clamav_up counter
+# TYPE clamav_up gauge
 clamav_up 1
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="left"><img src="https://storage.googleapis.com/gopherizeme.appspot.com/gophers/9e5f19f595edf1bb1a51cb49e4eac9f935c1ec18.png" alt="Logo" height="200"></p> 
+<p align="left"><img src="https://storage.googleapis.com/gopherizeme.appspot.com/gophers/9e5f19f595edf1bb1a51cb49e4eac9f935c1ec18.png" alt="Logo" height="200"></p>
 
 # ClamAV Prometheus Exporter
 
@@ -46,7 +46,7 @@ clamav_threads_live 1
 clamav_threads_max 12
 # HELP clamav_up Shows UP Status
 # TYPE clamav_up counter
-clamav_up 1 
+clamav_up 1
 ```
 
 ## Installation
@@ -58,7 +58,7 @@ ClamAV Prometheus Exporter requires a
 $ go get -u github.com/r3kzi/clamav-prometheus-exporter
 ```
 
-To find out where `clamav-prometheus-exporter` was installed you can run `$ go list -f {{.Target}} github.com/r3kzi/clamav-prometheus-exporter`. 
+To find out where `clamav-prometheus-exporter` was installed you can run `$ go list -f {{.Target}} github.com/r3kzi/clamav-prometheus-exporter`.
 
 For `clamav-prometheus-exporter` to be used globally add that directory to the `$PATH` environment setting.
 
@@ -82,7 +82,7 @@ Just scrape this, e.g.:
 scrape_configs:
   - job_name: 'clamav-prometheus-exporter'
     static_configs:
-      - targets: ['localhost:9090']
+      - targets: ['localhost:9810']
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -29,9 +29,15 @@ clamav_mem_heap_bytes 1.090783104e+06
 # HELP clamav_mem_mmap_bytes Shows mmap memory usage in bytes
 # TYPE clamav_mem_mmap_bytes gauge
 clamav_mem_mmap_bytes 1.076747264e+06
-# HELP clamav_mem_used_bytes Shows used memory usage in bytes
+# HELP clamav_mem_used_bytes Shows used memory in bytes
 # TYPE clamav_mem_used_bytes gauge
 clamav_mem_used_bytes 1.076783104e+06
+# HELP clamav_pools_total_bytes Shows total memory allocated by memory pool allocator for the signature database in bytes
+# TYPE clamav_pools_total_bytes gauge
+clamav_pools_total_bytes 1.076783104e+06
+# HELP clamav_pools_used_bytes Shows memory used by memory pool allocator for the signature database in bytes
+# TYPE clamav_pools_used_bytes gauge
+clamav_pools_used_bytes 1.076747264e+06
 # HELP clamav_queue_length Shows queued items
 # TYPE clamav_queue_length gauge
 clamav_queue_length 0

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - ./prometheus/:/etc/prometheus/
     ports:
-      - 9090:9090
+      - 9810:9810
     links:
       - clamav-prometheus-exporter:clamav-prometheus-exporter
 

--- a/example/prometheus/prometheus.yml
+++ b/example/prometheus/prometheus.yml
@@ -17,4 +17,4 @@ scrape_configs:
     # Override the global default and scrape targets from this job every 5 seconds.
     scrape_interval: 5s
     static_configs:
-      - targets: ['clamav-prometheus-exporter:9090']
+      - targets: ['clamav-prometheus-exporter:9810']

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,9 @@ google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyz
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20198102080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
+gopkg.in/check.v1 v1.0.0-20198102080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 	router.Handle("/metrics", promhttp.Handler())
 
 	server := &http.Server{
-		Addr:         fmt.Sprintf(":%v", 9090),
+		Addr:         fmt.Sprintf(":%v", 9810),
 		Handler:      router,
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
@@ -74,9 +74,9 @@ func main() {
 		close(done)
 	}()
 
-	log.Info("Server is ready to handle requests at :", 9090)
+	log.Info("Server is ready to handle requests at :", 9810)
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		log.Fatalf("Could not listen on %d: %v\n", 9090, err)
+		log.Fatalf("Could not listen on %d: %v\n", 9810, err)
 	}
 
 	<-done

--- a/pkg/clamav/tcp.go
+++ b/pkg/clamav/tcp.go
@@ -16,10 +16,11 @@ package clamav
 
 import (
 	"fmt"
-	"github.com/r3kzi/clamav-prometheus-exporter/pkg/commands"
-	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net"
+
+	"github.com/r3kzi/clamav-prometheus-exporter/pkg/commands"
+	log "github.com/sirupsen/logrus"
 )
 
 //Client corresponds to a ClamAV client

--- a/pkg/clamav/tcp_test.go
+++ b/pkg/clamav/tcp_test.go
@@ -17,13 +17,14 @@ package clamav
 import (
 	"bufio"
 	"fmt"
-	"github.com/r3kzi/clamav-prometheus-exporter/pkg/commands"
-	"github.com/stretchr/testify/assert"
 	"net"
 	"os"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/r3kzi/clamav-prometheus-exporter/pkg/commands"
+	"github.com/stretchr/testify/assert"
 )
 
 var (

--- a/pkg/clamav/tcp_test.go
+++ b/pkg/clamav/tcp_test.go
@@ -44,10 +44,10 @@ func TestMain(m *testing.M) {
 func TestPing(t *testing.T) {
 	go func() {
 		server, err := listener.Accept()
-		defer server.Close()
 		if err != nil {
 			t.Errorf("failed to accept connect: %s", err)
 		}
+		defer server.Close()
 		resp, err := bufio.NewReader(server).ReadBytes('\n')
 		if err != nil {
 			t.Errorf("failed to read request: %s", err)
@@ -64,10 +64,10 @@ func TestPing(t *testing.T) {
 func TestStats(t *testing.T) {
 	go func() {
 		server, err := listener.Accept()
-		defer server.Close()
 		if err != nil {
 			t.Errorf("failed to accept connect: %s", err)
 		}
+		defer server.Close()
 		resp, err := bufio.NewReader(server).ReadBytes('\n')
 		if err != nil {
 			t.Errorf("failed to read request: %s", err)
@@ -104,10 +104,10 @@ func TestStats(t *testing.T) {
 func TestVersion(t *testing.T) {
 	go func() {
 		server, err := listener.Accept()
-		defer server.Close()
 		if err != nil {
 			t.Errorf("failed to accept connect: %s", err)
 		}
+		defer server.Close()
 		resp, err := bufio.NewReader(server).ReadBytes('\n')
 		if err != nil {
 			t.Errorf("failed to read request: %s", err)
@@ -122,7 +122,7 @@ func TestVersion(t *testing.T) {
 	client := New(listener.Addr().String())
 	stats := client.Dial(commands.VERSION)
 
-	regex := regexp.MustCompile("((ClamAV)+\\s([0-9.]*)/([0-9.]*))")
+	regex := regexp.MustCompile(`((ClamAV)+\s([0-9.]*)/([0-9.]*))`)
 	matches := regex.FindAllStringSubmatch(string(stats), -1)
 
 	assert.Equal(t, "0.102.4", matches[0][3])

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -71,10 +71,10 @@ func (collector *Collector) Describe(ch chan<- *prometheus.Desc) {
 //Collect satisfies prometheus.Collector.Collect
 func (collector *Collector) Collect(ch chan<- prometheus.Metric) {
 	pong := collector.client.Dial(commands.PING)
-	if bytes.Compare(pong, []byte{'P', 'O', 'N', 'G', '\n'}) == 0 {
-		ch <- prometheus.MustNewConstMetric(collector.up, prometheus.CounterValue, 1)
+	if bytes.Equal(pong, []byte{'P', 'O', 'N', 'G', '\n'}) {
+		ch <- prometheus.MustNewConstMetric(collector.up, prometheus.GaugeValue, 1)
 	} else {
-		ch <- prometheus.MustNewConstMetric(collector.up, prometheus.CounterValue, 0)
+		ch <- prometheus.MustNewConstMetric(collector.up, prometheus.GaugeValue, 0)
 	}
 
 	float := func(s string) float64 {
@@ -89,17 +89,17 @@ func (collector *Collector) Collect(ch chan<- prometheus.Metric) {
 	regex := regexp.MustCompile("([0-9.]+)")
 	matches := regex.FindAllStringSubmatch(string(stats), -1)
 	if len(matches) > 0 {
-		ch <- prometheus.MustNewConstMetric(collector.threadsLive, prometheus.CounterValue, float(matches[1][1]))
-		ch <- prometheus.MustNewConstMetric(collector.threadsIdle, prometheus.CounterValue, float(matches[2][1]))
-		ch <- prometheus.MustNewConstMetric(collector.threadsMax, prometheus.CounterValue, float(matches[3][1]))
-		ch <- prometheus.MustNewConstMetric(collector.queue, prometheus.CounterValue, float(matches[5][1]))
+		ch <- prometheus.MustNewConstMetric(collector.threadsLive, prometheus.GaugeValue, float(matches[1][1]))
+		ch <- prometheus.MustNewConstMetric(collector.threadsIdle, prometheus.GaugeValue, float(matches[2][1]))
+		ch <- prometheus.MustNewConstMetric(collector.threadsMax, prometheus.GaugeValue, float(matches[3][1]))
+		ch <- prometheus.MustNewConstMetric(collector.queue, prometheus.GaugeValue, float(matches[5][1]))
 		ch <- prometheus.MustNewConstMetric(collector.memHeap, prometheus.GaugeValue, float(matches[7][1])*1024)
 		ch <- prometheus.MustNewConstMetric(collector.memMmap, prometheus.GaugeValue, float(matches[8][1])*1024)
 		ch <- prometheus.MustNewConstMetric(collector.memUsed, prometheus.GaugeValue, float(matches[9][1])*1024)
 	}
 
 	version := collector.client.Dial(commands.VERSION)
-	regex = regexp.MustCompile("((ClamAV)+\\s([0-9.]*)/([0-9.]*))")
+	regex = regexp.MustCompile(`((ClamAV)+\s([0-9.]*)/([0-9.]*))`)
 	matches = regex.FindAllStringSubmatch(string(version), -1)
 	if len(matches) > 0 {
 		ch <- prometheus.MustNewConstMetric(collector.buildInfo, prometheus.GaugeValue, 1, matches[0][3], matches[0][4])

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -16,7 +16,7 @@ package collector
 
 import (
 	"bytes"
-	"log"
+	"math"
 	"regexp"
 	"strconv"
 
@@ -73,12 +73,14 @@ func (collector *Collector) Collect(ch chan<- prometheus.Metric) {
 	pong := collector.client.Dial(commands.PING)
 	if bytes.Compare(pong, []byte{'P', 'O', 'N', 'G', '\n'}) == 0 {
 		ch <- prometheus.MustNewConstMetric(collector.up, prometheus.CounterValue, 1)
+	} else {
+		ch <- prometheus.MustNewConstMetric(collector.up, prometheus.CounterValue, 0)
 	}
 
 	float := func(s string) float64 {
 		float, err := strconv.ParseFloat(s, 64)
 		if err != nil {
-			log.Fatalf("couldn't parse string to float: %s", err)
+			float = math.NaN()
 		}
 		return float
 	}

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -16,12 +16,13 @@ package collector
 
 import (
 	"bytes"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/r3kzi/clamav-prometheus-exporter/pkg/clamav"
-	"github.com/r3kzi/clamav-prometheus-exporter/pkg/commands"
 	"log"
 	"regexp"
 	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/r3kzi/clamav-prometheus-exporter/pkg/clamav"
+	"github.com/r3kzi/clamav-prometheus-exporter/pkg/commands"
 )
 
 //Collector satisfies prometheus.Collector interface
@@ -46,10 +47,10 @@ func New(client clamav.Client) *Collector {
 		threadsLive: prometheus.NewDesc("clamav_threads_live", "Shows live threads", nil, nil),
 		threadsIdle: prometheus.NewDesc("clamav_threads_idle", "Shows idle threads", nil, nil),
 		threadsMax:  prometheus.NewDesc("clamav_threads_max", "Shows max threads", nil, nil),
-		queue:       prometheus.NewDesc("clamav_queue", "Shows queued items", nil, nil),
-		memHeap:     prometheus.NewDesc("clamav_mem_heap", "Shows heap memory usage", nil, nil),
-		memMmap:     prometheus.NewDesc("clamav_mem_mmap", "Shows mmap memory usage", nil, nil),
-		memUsed:     prometheus.NewDesc("clamav_mem_used", "Shows used memory usage", nil, nil),
+		queue:       prometheus.NewDesc("clamav_queue_length", "Shows queued items", nil, nil),
+		memHeap:     prometheus.NewDesc("clamav_mem_heap_bytes", "Shows heap memory usage in bytes", nil, nil),
+		memMmap:     prometheus.NewDesc("clamav_mem_mmap_bytes", "Shows mmap memory usage in bytes", nil, nil),
+		memUsed:     prometheus.NewDesc("clamav_mem_used_bytes", "Shows used memory usage in bytes", nil, nil),
 		buildInfo:   prometheus.NewDesc("clamav_build_info", "Shows ClamAV Build Info", []string{"clamav_version", "database_version"}, nil),
 	}
 }
@@ -90,9 +91,9 @@ func (collector *Collector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(collector.threadsIdle, prometheus.CounterValue, float(matches[2][1]))
 		ch <- prometheus.MustNewConstMetric(collector.threadsMax, prometheus.CounterValue, float(matches[3][1]))
 		ch <- prometheus.MustNewConstMetric(collector.queue, prometheus.CounterValue, float(matches[5][1]))
-		ch <- prometheus.MustNewConstMetric(collector.memHeap, prometheus.GaugeValue, float(matches[7][1]))
-		ch <- prometheus.MustNewConstMetric(collector.memMmap, prometheus.GaugeValue, float(matches[8][1]))
-		ch <- prometheus.MustNewConstMetric(collector.memUsed, prometheus.GaugeValue, float(matches[9][1]))
+		ch <- prometheus.MustNewConstMetric(collector.memHeap, prometheus.GaugeValue, float(matches[7][1])*1024)
+		ch <- prometheus.MustNewConstMetric(collector.memMmap, prometheus.GaugeValue, float(matches[8][1])*1024)
+		ch <- prometheus.MustNewConstMetric(collector.memUsed, prometheus.GaugeValue, float(matches[9][1])*1024)
 	}
 
 	version := collector.client.Dial(commands.VERSION)

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -30,6 +30,7 @@ var (
 	//Replies with statistics about the scan queue, contents of scan queue, and memory usage.
 	STATS = Command{Name: "STATS", Prefix: "n"}
 
+	//VERSION - ClamAV version and database information
 	VERSION = Command{Name: "VERSION", Prefix: ""}
 )
 


### PR DESCRIPTION
Thanks for writing this exporter. 
Here are a few, hopefully, improvements:

* Run on port 9810. Picked one from [Default port allocations](https://github.com/prometheus/prometheus/wiki/Default-port-allocations). `9090` is not the best choice, since Prometheus itself also uses that port. Good idea would be to claim and "register" `9810` (or any other free port) and use that going forward.
* Changed metric type from `counter` (supposed to only increase) to `gauge` where applicable.
* Transform memory metrics to be in [bytes](https://prometheus.io/docs/instrumenting/writing_exporters/#naming), update description to make it clear.
* Added `poolsUsed` and `poolsTotal` metrics.
* Updated regexp matcher to match `N/A` as well. This is because, apparently, when running ClamAV in docker, it shows `N/A` for `heap`, `mmap` and `used` memory, and only shows numbers for pool metrics.
* Fixed so the exporter does not die when it fails to parse a string (e.g. the `N/A` from above), and instead just report it as `NaN`, and move on.
* Fixed the exporter not showing any `clamav_*` metrics when it cannot reach ClamAV for some reason. It now shows `clamav_up 0`, if that is the case. This should simplify alert rule logic, if one would want to get an alert when ClamAV is down.
* Some other minor stuff suggested by syntax checker.