### PR TITLE
Update go version

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,9 +4,14 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v*
   pull_request:
     branches:
       - master
+
+env:
+  IMAGE_NAME: clamav-prometheus-exporter
 
 jobs:
   build:
@@ -22,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: 1.23
 
       # Build the application
       - name: Build Go Application
@@ -43,14 +48,15 @@ jobs:
       # Build the Docker image
       - name: Build Docker Image
         run: |
-          docker build -t clamav-prometheus-exporter:latest .
+          docker build . -f Dockerfile -t $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
 
   push:
     name: Push Docker Image to Docker Hub
     runs-on: ubuntu-latest
     needs: [build, docker-build] # Ensure this job runs after "build" and "docker-build"
 
-    if: github.event_name == 'push' # Only run for "push" events, not "pull_request"
+    # Only run for "push" events and on the owner repository, not for "pull_request"
+    if: github.event_name == 'push' && github.repository_owner == 'r3kzi'
 
     steps:
       # Checkout the repository
@@ -67,5 +73,13 @@ jobs:
       # Push the Docker image
       - name: Push Docker Image
         run: |
-          docker build -t ${{ secrets.DOCKER_HUB_USERNAME }}/clamav-prometheus-exporter:latest .
-          docker push ${{ secrets.DOCKER_HUB_USERNAME }}/clamav-prometheus-exporter:latest
+          IMAGE_ID=${{ secrets.DOCKER_HUB_USERNAME }}/$IMAGE_NAME
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          VERSION=latest
+
+          [[ "${{ github.ref_type }}" == "tag" ]] && VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,;s/^v//')
+
+          echo VERSION=$VERSION
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
 # First stage: build the executable.
-FROM golang:1.21 as builder
+FROM golang:1.23-alpine as builder
 WORKDIR /go/src/github.com/rekzi/clamav-prometheus-exporter/
 COPY . .
-# CGO_ENABLED=0 to build a statically-linked executable
 
-ENV CGO_ENABLED=0
-RUN go build -installsuffix 'static' -o clamav-prometheus-exporter .
+RUN apk add --no-cache make
+RUN make build
 
 # Final stage: the running container.
 # Use a minimal image for running the application
-FROM alpine:3.18 AS final
+FROM alpine:3.21 AS final
 
 # Install necessary certificates
 RUN apk add --no-cache ca-certificates

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
+IMAGE_TAG=latest
+NAME=clamav-prometheus-exporter
+OWNER=rekzi
+
 build:
-	CGO_ENABLED=0 && go build -installsuffix 'static' -o clamav-prometheus-exporter .
+	CGO_ENABLED=0 && go build -installsuffix 'static' -o ${NAME} .
 image:
-	docker build -t clamav-prometheus-exporter -t rekzi/clamav-prometheus-exporter:latest .
+	docker build -t ${NAME} -t ${OWNER}/${NAME}:${IMAGE_TAG} .
 push:
-	docker push rekzi/clamav-prometheus-exporter:latest
+	docker push ${OWNER}/${NAME}:${IMAGE_TAG}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/r3kzi/clamav-prometheus-exporter
 
-go 1.21
+go 1.23
 
 require (
 	github.com/prometheus/client_golang v1.20.5


### PR DESCRIPTION
The goal of this change is to update the Go version from 1.21 to 1.23.

In addition, the ability to version Docker images based on tags in the repository has been added. This will allow you to generate controlled versions of the application.