### PR TITLE
(Fix): Adding build image step in the Push phase of the pipeline

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   IMAGE_NAME: clamav-prometheus-exporter
+  IMAGE_TAG: latest
 
 jobs:
   build:
@@ -48,7 +49,7 @@ jobs:
       # Build the Docker image
       - name: Build Docker Image
         run: |
-          docker build . -f Dockerfile -t $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+          docker build . -f Dockerfile -t $IMAGE_NAME:$IMAGE_TAG
 
   push:
     name: Push Docker Image to Docker Hub
@@ -63,6 +64,11 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
+      # Build the Docker image
+      - name: Build Docker Image
+        run: |
+          docker build . -f Dockerfile -t $IMAGE_NAME:$IMAGE_TAG --label "runnumber=${GITHUB_RUN_ID}"
+
       # Log in to Docker Hub
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
@@ -75,11 +81,11 @@ jobs:
         run: |
           IMAGE_ID=${{ secrets.DOCKER_HUB_USERNAME }}/$IMAGE_NAME
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          VERSION=latest
+          VERSION=$IMAGE_TAG
 
           [[ "${{ github.ref_type }}" == "tag" ]] && VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,;s/^v//')
 
           echo VERSION=$VERSION
 
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker tag $IMAGE_NAME:$IMAGE_TAG $IMAGE_ID:$VERSION
           docker push $IMAGE_ID:$VERSION

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
+
 # Binaries for programs and plugins
 *.exe
 *.exe~
 *.dll
 *.so
 *.dylib
+clamav-prometheus-exporter
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
This change fixes a bug that was introduced when removing the docker build command in the Push phase.
I imagined that one phase (push) would take advantage of the result of another phase (docker-build) to avoid having to run docker build twice, but that is not possible.
I also removed the binary I accidentally added in the commit, as well as putting it in gitignore to avoid future errors.
C/c: @r3kzi 