### PR TITLE
feat(build): Add ability to generate image tag based on github tag

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,8 +11,7 @@ on:
       - master
 
 env:
-  IMAGE_NAME: clamav-prometheus-exporter
-  IMAGE_TAG: latest
+  VERSION: latest
 
 jobs:
   build:
@@ -48,8 +47,7 @@ jobs:
 
       # Build the Docker image
       - name: Build Docker Image
-        run: |
-          docker build . -f Dockerfile -t $IMAGE_NAME:$IMAGE_TAG
+        run: make image VERSION=$VERSION
 
   push:
     name: Push Docker Image to Docker Hub
@@ -67,7 +65,11 @@ jobs:
       # Build the Docker image
       - name: Build Docker Image
         run: |
-          docker build . -f Dockerfile -t $IMAGE_NAME:$IMAGE_TAG --label "runnumber=${GITHUB_RUN_ID}"
+          [[ "${{ github.ref_type }}" == "tag" ]] && VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,;s/^v//')
+
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+          make image VERSION=$VERSION IMAGE_EXTRA_ARGS='--label "runnumber=${GITHUB_RUN_ID}"'
 
       # Log in to Docker Hub
       - name: Log in to Docker Hub
@@ -78,14 +80,4 @@ jobs:
 
       # Push the Docker image
       - name: Push Docker Image
-        run: |
-          IMAGE_ID=${{ secrets.DOCKER_HUB_USERNAME }}/$IMAGE_NAME
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          VERSION=$IMAGE_TAG
-
-          [[ "${{ github.ref_type }}" == "tag" ]] && VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,;s/^v//')
-
-          echo VERSION=$VERSION
-
-          docker tag $IMAGE_NAME:$IMAGE_TAG $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+        run: make push VERSION=$VERSION"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
-IMAGE_TAG=latest
-NAME=clamav-prometheus-exporter
-OWNER=rekzi
+OUT:=clamav-prometheus-exporter
+OWNER:=rekzi
+VERSION:=latest
+IMAGE:=$(OWNER)/$(OUT):$(VERSION)
+IMAGE_EXTRA_ARGS?=
 
 build:
-	CGO_ENABLED=0 && go build -installsuffix 'static' -o ${NAME} .
+	CGO_ENABLED=0 && go build -installsuffix 'static' -o ${OUT} .
+build-version:
+	CGO_ENABLED=0 && go build -installsuffix 'static' -o ${OUT} -ldflags="-X main.version=${VERSION}" .
 image:
-	docker build -t ${NAME} -t ${OWNER}/${NAME}:${IMAGE_TAG} .
+	docker build -t ${OUT} -t ${IMAGE} ${IMAGE_EXTRA_ARGS} .
 push:
-	docker push ${OWNER}/${NAME}:${IMAGE_TAG}
+	docker push ${IMAGE}
+clean:
+	rm -rf $(OUT)

--- a/main.go
+++ b/main.go
@@ -32,6 +32,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var version = ""
+
 var (
 	address string
 	port    int
@@ -75,6 +77,7 @@ func init() {
 
 func main() {
 	log.Info("Server is starting...")
+	log.Infof("Version: %s", version)
 
 	if strings.EqualFold(network, "tcp") {
 		address = fmt.Sprintf("%s:%d", address, port)


### PR DESCRIPTION
This change adds the possibility of creating Docker images published on Dockerhub based on releases generated on Github.
This will give the repository maintainer the possibility of creating releases on GitHub when necessary, and thus generating image versions automatically.

In addition, this version is also added as a property in the application, so that we can know exactly which version the binary was compiled.

Last but not least, the GitHub action job was integrated to use the commands defined in the Makefile. This way, we can always keep the image build logic, application compilation, and the like in the same place.

C/c: @r3kzi 